### PR TITLE
fix: don't trigger the niceSelect click cascade on init

### DIFF
--- a/static/js/monospace.js
+++ b/static/js/monospace.js
@@ -1,5 +1,24 @@
 'use strict';
 
-exports.postAceInit = () => {
-  $('ul').find('[data-value=RobotoMono]').click();
+// Default the pad font to RobotoMono for new sessions.
+//
+// Older revision: `$('ul').find('[data-value=RobotoMono]').click()` —
+// this triggered the niceSelect dropdown's click cascade, which under
+// the current Etherpad reads the font-menu's bounding rect via jQuery's
+// trigger pipeline and threw `TypeError: Cannot read properties of
+// undefined (reading 'top')` if the dropdown wasn't fully positioned at
+// postAceInit time. The exception leaked into the global error gritter
+// path, breaking error_sanitization.spec.ts.
+//
+// The same effect can be achieved without going through the click
+// cascade: set the ace property + the select's value directly, then
+// nudge niceSelect to redraw the visible label. This mirrors what
+// padeditor.setViewOptions does internally for `padFontFamily`.
+exports.postAceInit = (hook, context) => {
+  const FONT = 'RobotoMono';
+  const select = $('#viewfontmenu');
+  if (select.find(`option[value=${FONT}]`).length === 0) return; // skin/build doesn't ship the font
+  context.ace.setProperty('textface', FONT);
+  select.val(FONT);
+  if (select.niceSelect) select.niceSelect('update');
 };


### PR DESCRIPTION
## Why

Previous `postAceInit` did `$('ul').find('[data-value=RobotoMono]').click()`. The click bubbles through niceSelect's positioning code which reads the dropdown's bounding rect via jQuery's `trigger` pipeline. If postAceInit fires before the dropdown is fully positioned (which it does in CI), that read returns `undefined` and throws `TypeError: Cannot read properties of undefined (reading 'top')`. The unhandled exception leaks into the global error gritter path, which breaks **error_sanitization.spec.ts:10/45/70** — those specs assert that no unrelated error gritter is in flight when they trigger their own.

## Fix

Same effect without the cascade: set the ace `textface` property + the underlying `<select>` value directly, then nudge niceSelect to redraw the visible label. Mirrors what [`padeditor.setViewOptions`](https://github.com/ether/etherpad-lite/blob/develop/src/static/js/pad_editor.ts#L272) does for `padFontFamily` internally.

Skip the whole thing if the font isn't in the dropdown (custom skin / build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)